### PR TITLE
Fix theme chooser to show only one theme at a time

### DIFF
--- a/bootstrap/css/jumbotron-narrow.css
+++ b/bootstrap/css/jumbotron-narrow.css
@@ -122,3 +122,24 @@ body {
     opacity: 0;
   }
 }
+
+/* Set background color to white for snow class */
+.snow {
+  background-color: white;
+}
+
+/* Set background color to black for starfield class */
+.starfield {
+  background-color: black;
+}
+
+/* Styles for the starfield background */
+#starfield {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  background: black;
+}

--- a/index.html
+++ b/index.html
@@ -198,6 +198,8 @@
       -->
     </div><!-- /.container -->
 
+    <canvas id="starfield"></canvas>
+
     <script>
       document.getElementById('theme-switcher').addEventListener('click', function() {
         var theme = document.body.classList.contains('snow') ? 'dark' : 'light';
@@ -205,17 +207,22 @@
           document.body.classList.remove('starfield');
           document.body.classList.add('snow');
           this.innerHTML = '❄️';
+          removeElementsByClass('star');
           addSnowflakes();
+          document.body.style.backgroundColor = 'white';
         } else {
           document.body.classList.remove('snow');
           document.body.classList.add('starfield');
           this.innerHTML = '⭐';
+          removeElementsByClass('snowflake');
           addStars();
+          document.body.style.backgroundColor = 'black';
         }
       });
 
       // Add snowflakes and stars
       function addSnowflakes() {
+        removeElementsByClass('snowflake');
         for (var i = 0; i < 100; i++) {
           var snowflake = document.createElement('div');
           snowflake.className = 'snowflake';
@@ -227,6 +234,7 @@
       }
 
       function addStars() {
+        removeElementsByClass('star');
         for (var i = 0; i < 100; i++) {
           var star = document.createElement('div');
           star.className = 'star';
@@ -238,14 +246,25 @@
         }
       }
 
+      function removeElementsByClass(className) {
+        var elements = document.getElementsByClassName(className);
+        while (elements.length > 0) {
+          elements[0].parentNode.removeChild(elements[0]);
+        }
+      }
+
       // Add snowflakes or stars based on the initial theme
       var initialTheme = document.body.classList.contains('snow') ? 'light' : 'dark';
       if (initialTheme === 'light') {
         addSnowflakes();
+        document.body.style.backgroundColor = 'white';
       } else {
         addStars();
+        document.body.style.backgroundColor = 'black';
       }
     </script>
+
+    <script src="starfield.js"></script>
 
   </body>
 </html>

--- a/starfield.js
+++ b/starfield.js
@@ -1,0 +1,76 @@
+const canvas = document.getElementById('starfield');
+const ctx = canvas.getContext('2d');
+
+let stars = [];
+const numStars = 100;
+const speed = 2;
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+function createStars() {
+  for (let i = 0; i < numStars; i++) {
+    stars.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      z: Math.random() * canvas.width,
+    });
+  }
+}
+
+function moveStars() {
+  for (let i = 0; i < numStars; i++) {
+    stars[i].z -= speed;
+    if (stars[i].z <= 0) {
+      stars[i].z = canvas.width;
+    }
+  }
+}
+
+function drawStars() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let i = 0; i < numStars; i++) {
+    const k = 128.0 / stars[i].z;
+    const x = stars[i].x * k + canvas.width / 2;
+    const y = stars[i].y * k + canvas.height / 2;
+    const size = (1 - stars[i].z / canvas.width) * 5;
+    ctx.beginPath();
+    ctx.arc(x, y, size, 0, 2 * Math.PI);
+    ctx.fillStyle = 'white';
+    ctx.fill();
+  }
+}
+
+function animate() {
+  moveStars();
+  drawStars();
+  requestAnimationFrame(animate);
+}
+
+function onMouseMove(event) {
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+  const deltaX = event.clientX - centerX;
+  const deltaY = event.clientY - centerY;
+  for (let i = 0; i < numStars; i++) {
+    stars[i].x += deltaX * 0.01;
+    stars[i].y += deltaY * 0.01;
+  }
+}
+
+function onTouchMove(event) {
+  if (event.touches.length > 0) {
+    const touch = event.touches[0];
+    onMouseMove(touch);
+  }
+}
+
+window.addEventListener('resize', resizeCanvas);
+canvas.addEventListener('mousemove', onMouseMove);
+canvas.addEventListener('touchmove', onTouchMove);
+
+resizeCanvas();
+createStars();
+animate();


### PR DESCRIPTION
Fix the theme chooser to show only one theme at a time and update the background color accordingly.

* **index.html**
  - Add a canvas element with id `starfield` for the starfield background.
  - Update the `theme-switcher` event listener to remove old elements before adding new ones.
  - Update the `addSnowflakes` function to remove old snowflakes before adding new ones.
  - Update the `addStars` function to remove old stars before adding new ones.
  - Update the `theme-switcher` event listener to change the background color based on the theme.
  - Add a function `removeElementsByClass` to remove elements by class name.
  - Add initial background color setting based on the initial theme.
  - Include `starfield.js` script.

* **bootstrap/css/jumbotron-narrow.css**
  - Add CSS rule to set the background color to white for the `snow` class.
  - Add CSS rule to set the background color to black for the `starfield` class.
  - Add CSS rule for the `#starfield` element to follow the provided styles.

* **starfield.js**
  - Add the provided JavaScript code for the starfield animation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ryleyherrington/ryleyherrington.github.io?shareId=ae1c133b-2b1e-4220-bf83-8c5f9ef4fc60).